### PR TITLE
IPの使用量によって課金する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'yao', :github => 'yaocloud/yao', :branch => 'add-tenant-port-list'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'yao', :github => 'yaocloud/yao', :branch => 'add-tenant-port-list'

--- a/cost.yaml.sample
+++ b/cost.yaml.sample
@@ -1,4 +1,5 @@
 vcpu_per_hour: 1
 memory_mb_per_hour: 0.0009765625
 disk_gb_per_hour: 1
+cost_per_ip: 1
 ip_regexp: ^192.128

--- a/lib/kakin/cli.rb
+++ b/lib/kakin/cli.rb
@@ -93,5 +93,26 @@ module Kakin
 
       puts YAML.dump(result)
     end
+
+    option :f, type: :string, banner: "<file>", desc: "cost define file(yaml)", required: true
+    desc 'ip', 'ip use count'
+    def ip
+      Kakin::Configuration.setup
+
+      yaml = YAML.load_file(options[:f])
+      ip_regexp = Regexp.new(yaml["ip_regexp"])
+
+      result = Hash.new
+      tenants = Yao::Tenant.list
+      tenants.each do |tenant|
+        count = tenant.ports.select {|p| p.fixed_ips[0]["ip_address"] =~ ip_regexp}.count
+        result[tenant.name] = {
+          'count'       => count,
+          'total_usage' => count * yaml["cost_per_ip"],
+        }
+      end
+
+      puts YAML.dump(result)
+    end
   end
 end


### PR DESCRIPTION
テナント毎に使用しているIPの数で課金する仕組みを追加します。
対象のIPレンジは `cost.yaml` の `ip_regexp` で指定します。
この変更で `cost.yaml` に `cost_per_ip` というフィールドを追加しています。
