### PR TITLE
Use environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ You need to create configuration file located `~/.kakin` for openstack credentia
 
 ```
 auth_url: "http://your-openstack-host:35357/v2.0/tokens"
-management_url: "http://your-openstack-host:8774/v2"
 username: "username"
 tenant: "your-admin-tenant"
 password: "password"
+```
+
+Or set with environment variable.
+
+```
+export OS_AUTH_URL=<your openstack auth url>
+export OS_USER=<your username>
+export OS_TENANT_NAME=<your tenant>
+export OS_PASSWORD=<your password>
 ```
 
 You can get resource usage with following command.

--- a/lib/kakin/configuration.rb
+++ b/lib/kakin/configuration.rb
@@ -1,10 +1,6 @@
 module Kakin
   class Configuration
 
-    def self.management_url
-      @@_management_url
-    end
-
     def self.tenant
       @@_tenant
     end
@@ -31,7 +27,6 @@ module Kakin
         config.merge!(yaml)
       end
 
-      @@_management_url = config['management_url']
       @@_tenant = config['tenant']
 
       Yao.configure do

--- a/lib/kakin/configuration.rb
+++ b/lib/kakin/configuration.rb
@@ -22,6 +22,7 @@ module Kakin
         'project_domain_name'  => ENV['OS_PROJECT_DOMAIN_NAME'],
         'timeout'              => ENV['YAO_TIMEOUT'],
         'management_url'       => ENV['YAO_MANAGEMENT_URL'],
+        'debug'                => ENV['YAO_DEBUG'] || false,
       }
 
       file_path = File.expand_path('~/.kakin')
@@ -44,6 +45,7 @@ module Kakin
         identity_api_version config['identity_api_version'] if config['identity_api_version']
         user_domain_name config['user_domain_name'] if config['user_domain_name']
         project_domain_name config['project_domain_name'] if config['project_domain_name']
+        debug config['debug']
       end
     end
   end

--- a/lib/kakin/configuration.rb
+++ b/lib/kakin/configuration.rb
@@ -10,19 +10,34 @@ module Kakin
     end
 
     def self.setup
-      yaml = YAML.load_file(File.expand_path('~/.kakin'))
+      config = {
+        'auth_url'       => ENV['OS_AUTH_URL'],
+        'tenant'         => ENV['OS_TENANT_NAME'] || ENV['OS_PROJECT_NAME'],
+        'username'       => ENV['OS_USERNAME'],
+        'password'       => ENV['OS_PASSWORD'],
+        'client_cert'    => ENV['OS_CERT'],
+        'client_key'     => ENV['OS_KEY'],
+        'timeout'        => ENV['YAO_TIMEOUT'],
+        'management_url' => ENV['YAO_MANAGEMENT_URL'],
+      }
 
-      @@_management_url = yaml['management_url']
-      @@_tenant = yaml['tenant']
+      file_path = File.expand_path('~/.kakin')
+      if File.exist?(file_path)
+        yaml = YAML.load_file(file_path)
+        config.merge!(yaml)
+      end
+
+      @@_management_url = config['management_url']
+      @@_tenant = config['tenant']
 
       Yao.configure do
-        auth_url yaml['auth_url']
-        tenant_name yaml['tenant']
-        username yaml['username']
-        password yaml['password']
-        timeout yaml['timeout'] if yaml['timeout']
-        client_cert yaml['client_cert'] if yaml['client_cert']
-        client_key yaml['client_key'] if yaml['client_key']
+        auth_url config['auth_url']
+        tenant_name config['tenant']
+        username config['username']
+        password config['password']
+        timeout config['timeout'] if config['timeout']
+        client_cert config['client_cert'] if config['client_cert']
+        client_key config['client_key'] if config['client_key']
       end
     end
   end

--- a/lib/kakin/configuration.rb
+++ b/lib/kakin/configuration.rb
@@ -11,14 +11,17 @@ module Kakin
 
     def self.setup
       config = {
-        'auth_url'       => ENV['OS_AUTH_URL'],
-        'tenant'         => ENV['OS_TENANT_NAME'] || ENV['OS_PROJECT_NAME'],
-        'username'       => ENV['OS_USERNAME'],
-        'password'       => ENV['OS_PASSWORD'],
-        'client_cert'    => ENV['OS_CERT'],
-        'client_key'     => ENV['OS_KEY'],
-        'timeout'        => ENV['YAO_TIMEOUT'],
-        'management_url' => ENV['YAO_MANAGEMENT_URL'],
+        'auth_url'             => ENV['OS_AUTH_URL'],
+        'tenant'               => ENV['OS_TENANT_NAME'] || ENV['OS_PROJECT_NAME'],
+        'username'             => ENV['OS_USERNAME'],
+        'password'             => ENV['OS_PASSWORD'],
+        'client_cert'          => ENV['OS_CERT'],
+        'client_key'           => ENV['OS_KEY'],
+        'identity_api_version' => ENV['OS_IDENTITY_API_VERSION'],
+        'user_domain_name'     => ENV['OS_USER_DOMAIN_NAME'],
+        'project_domain_name'  => ENV['OS_PROJECT_DOMAIN_NAME'],
+        'timeout'              => ENV['YAO_TIMEOUT'],
+        'management_url'       => ENV['YAO_MANAGEMENT_URL'],
       }
 
       file_path = File.expand_path('~/.kakin')
@@ -38,6 +41,9 @@ module Kakin
         timeout config['timeout'] if config['timeout']
         client_cert config['client_cert'] if config['client_cert']
         client_key config['client_key'] if config['client_key']
+        identity_api_version config['identity_api_version'] if config['identity_api_version']
+        user_domain_name config['user_domain_name'] if config['user_domain_name']
+        project_domain_name config['project_domain_name'] if config['project_domain_name']
       end
     end
   end


### PR DESCRIPTION
openstackclienti compatible environment variables are referenced.

- - - -
openstackclientと同じ環境変数を参照するようにした。
`~/.kakin.yml` も引き続き使えます。